### PR TITLE
feat(terminal): custom pane and tab labels

### DIFF
--- a/.changeset/custom-tab-labels.md
+++ b/.changeset/custom-tab-labels.md
@@ -1,0 +1,9 @@
+---
+"@omnidotdev/terminal": minor
+---
+
+Add custom tab labels. Press `Ctrl+Shift+L` (`Cmd+Shift+L` on macOS) or bind the new `renametab` action to open a prompt and give the current tab a human-readable name. A custom label overrides the auto-derived title template and is not overwritten by process, working-directory, or OSC title changes. Committing an empty value clears the label and reverts the tab to its automatic title.
+
+In the `TopTab`/`BottomTab` navigation modes, labeling a single tab reveals the tab bar so the name is visible in-window even with `hide-if-single` enabled; clearing the label hides it again. Tab-name rendering is now truncated by character rather than byte to avoid panicking on multibyte (unicode) names.
+
+Labels are per-pane: `renameTab` names the focused pane. The focused pane's label drives the tab title, and in a split each labeled pane reserves a one-line title strip at its top showing the name, so every pane name is visible at once without overlapping content.

--- a/frontends/omni-terminal/src/bindings/mod.rs
+++ b/frontends/omni-terminal/src/bindings/mod.rs
@@ -247,6 +247,7 @@ impl From<String> for Action {
             "resetopacity" => Some(Action::ResetOpacity),
             "createwindow" => Some(Action::WindowCreateNew),
             "createtab" => Some(Action::TabCreateNew),
+            "renametab" => Some(Action::RenameTab),
             "movecurrenttabtoprev" => Some(Action::MoveCurrentTabToPrev),
             "movecurrenttabtonext" => Some(Action::MoveCurrentTabToNext),
             "closetab" => Some(Action::TabCloseCurrent),
@@ -439,6 +440,9 @@ pub enum Action {
 
     /// Create a new Omni Terminal tab.
     TabCreateNew,
+
+    /// Prompt for a user-defined label for the current tab.
+    RenameTab,
 
     /// Move current tab to previous slot.
     MoveCurrentTabToPrev,
@@ -1046,6 +1050,7 @@ pub fn platform_key_bindings(
         key_bindings.extend(bindings!(
             KeyBinding;
             "t", ModifiersState::SUPER; Action::TabCreateNew;
+            "l", ModifiersState::SUPER | ModifiersState::SHIFT; Action::RenameTab;
             Key::Named(Tab), ModifiersState::CONTROL; Action::SelectNextTab;
             Key::Named(Tab), ModifiersState::CONTROL | ModifiersState::SHIFT; Action::SelectPrevTab;
             "w", ModifiersState::SUPER; Action::CloseCurrentSplitOrTab;
@@ -1134,6 +1139,7 @@ pub fn platform_key_bindings(
         key_bindings.extend(bindings!(
             KeyBinding;
             "t", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::TabCreateNew;
+            "l", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::RenameTab;
             Key::Named(Tab), ModifiersState::CONTROL; Action::SelectNextTab;
             Key::Named(Tab), ModifiersState::CONTROL | ModifiersState::SHIFT; Action::SelectPrevTab;
             "[", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::SelectPrevTab;
@@ -1208,6 +1214,7 @@ pub fn platform_key_bindings(
         key_bindings.extend(bindings!(
             KeyBinding;
             "t", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::TabCreateNew;
+            "l", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::RenameTab;
             Key::Named(Tab), ModifiersState::CONTROL; Action::SelectNextTab;
             Key::Named(Tab), ModifiersState::CONTROL | ModifiersState::SHIFT; Action::SelectPrevTab;
             "w", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::CloseCurrentSplitOrTab;

--- a/frontends/omni-terminal/src/context/grid.rs
+++ b/frontends/omni-terminal/src/context/grid.rs
@@ -55,6 +55,16 @@ fn compute(
     (visible_columns, visible_lines)
 }
 
+/// Height (in logical pixels) of the title strip reserved above a labeled
+/// pane, equal to one line of text
+#[inline]
+fn pane_title_strip_height(dimension: &ContextDimension) -> f32 {
+    if dimension.dimension.scale <= 0.0 {
+        return 0.0;
+    }
+    (dimension.dimension.height / dimension.dimension.scale) * dimension.line_height
+}
+
 #[inline]
 fn create_border(color: [f32; 4], position: [f32; 2], size: [f32; 2]) -> Object {
     Object::Quad(Quad {
@@ -94,6 +104,9 @@ pub struct ContextGridItem<T: EventListener> {
     down: Option<usize>,
     parent: Option<usize>,
     rich_text_object: Object,
+    /// User-defined label for this pane. When set, it overrides the
+    /// auto-derived title template and survives process/cwd changes
+    pub custom_label: Option<String>,
 }
 
 impl<T: terminal_backend::event::EventListener> ContextGridItem<T> {
@@ -110,6 +123,7 @@ impl<T: terminal_backend::event::EventListener> ContextGridItem<T> {
             down: None,
             parent: None,
             rich_text_object,
+            custom_label: None,
         }
     }
 }
@@ -315,6 +329,42 @@ impl<T: terminal_backend::event::EventListener> ContextGrid<T> {
     #[allow(unused)]
     pub fn current_key(&self) -> usize {
         self.current
+    }
+
+    /// The user-defined label of the focused pane, if one is set
+    #[inline]
+    pub fn current_label(&self) -> Option<String> {
+        self.inner
+            .get(&self.current)
+            .and_then(|item| item.custom_label.clone())
+    }
+
+    /// Set (or clear, with `None`) the user-defined label of the focused pane.
+    /// Re-lays out so the reserved title strip is added or removed immediately
+    #[inline]
+    pub fn set_current_label(&mut self, label: Option<String>) {
+        let key = self.current;
+        if let Some(item) = self.inner.get_mut(&key) {
+            item.custom_label = label;
+        }
+        self.calculate_positions();
+    }
+
+    /// Anchor position (the reserved top strip) and label of every pane in this
+    /// tab that carries a user-defined label, for rendering per-pane banners.
+    /// The strip sits one line above the shifted-down pane content
+    #[inline]
+    pub fn labeled_panes(&self) -> Vec<([f32; 2], String)> {
+        self.inner
+            .values()
+            .filter_map(|item| {
+                item.custom_label.as_ref().map(|label| {
+                    let strip = pane_title_strip_height(&item.val.dimension);
+                    let pos = item.position();
+                    ([pos[0], pos[1] - strip], label.clone())
+                })
+            })
+            .collect()
     }
 
     #[inline]
@@ -772,9 +822,20 @@ impl<T: terminal_backend::event::EventListener> ContextGrid<T> {
 
     /// Recursively calculate positions for grid items
     fn calculate_positions_recursive(&mut self, key: usize, margin: Delta<f32>) {
+        // A labeled pane in a split reserves its top line for a title strip,
+        // shifting content down by one line into the slack `compute` leaves at
+        // the pane bottom (no PTY resize; the allocated box is unchanged so
+        // stacked/side-by-side panes still lay out correctly)
+        let is_split = self.inner.len() > 1;
         if let Some(item) = self.inner.get_mut(&key) {
+            let strip = if is_split && item.custom_label.is_some() {
+                pane_title_strip_height(&item.val.dimension)
+            } else {
+                0.0
+            };
+
             // Set position for current item in the rich text object
-            item.set_position([margin.x, margin.top_y]);
+            item.set_position([margin.x, margin.top_y + strip]);
 
             // Calculate margin for down item
             let down_margin = Delta {
@@ -2069,6 +2130,39 @@ pub mod test {
                 lines: None,
             },)]
         );
+    }
+
+    #[test]
+    fn test_custom_label_defaults_none_and_is_settable() {
+        let context_dimension = ContextDimension::build(
+            1200.0,
+            800.0,
+            SugarDimensions {
+                scale: 2.,
+                width: 18.,
+                height: 9.,
+            },
+            1.0,
+            Delta::<f32>::default(),
+        );
+        let context =
+            create_mock_context(VoidListener {}, WindowId::from(0), 0, context_dimension);
+        let mut grid = ContextGrid::<VoidListener>::new(
+            context,
+            Delta::<f32>::default(),
+            [0., 0., 0., 0.],
+        );
+
+        // A freshly created pane has no user-defined label
+        assert_eq!(grid.current_label(), None);
+
+        // Setting a label on the focused pane sticks
+        grid.set_current_label(Some("deploy".to_string()));
+        assert_eq!(grid.current_label().as_deref(), Some("deploy"));
+
+        // Clearing reverts to the auto-derived title
+        grid.set_current_label(None);
+        assert_eq!(grid.current_label(), None);
     }
 
     #[test]

--- a/frontends/omni-terminal/src/context/mod.rs
+++ b/frontends/omni-terminal/src/context/mod.rs
@@ -677,6 +677,25 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             .send_event(TerminalEvent::CreateConfigEditor, self.window_id);
     }
 
+    /// The user-defined label of the focused pane, if one is set
+    #[inline]
+    pub fn current_pane_label(&self) -> Option<String> {
+        self.contexts
+            .get(self.current_index)
+            .and_then(|grid| grid.current_label())
+    }
+
+    /// Set (or clear, with `None`) the user-defined label of the focused pane.
+    /// Clears the throttle so the tab title refreshes on the next cycle
+    #[inline]
+    pub fn set_current_pane_label(&mut self, label: Option<String>) {
+        let idx = self.current_index;
+        if let Some(grid) = self.contexts.get_mut(idx) {
+            grid.set_current_label(label);
+        }
+        self.titles.last_title_update = None;
+    }
+
     #[inline]
     pub fn select_route_from_current_grid(&mut self) {
         self.current_route = self.current().route_id;
@@ -685,6 +704,24 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     #[inline]
     pub fn extend_with_grid_objects(&self, target: &mut Vec<Object>) {
         self.contexts[self.current_index].extend_with_objects(target);
+    }
+
+    /// Whether the current tab is split into more than one pane
+    #[inline]
+    pub fn current_is_split(&self) -> bool {
+        self.contexts
+            .get(self.current_index)
+            .map(|grid| grid.len() > 1)
+            .unwrap_or(false)
+    }
+
+    /// Positions and labels of labeled panes in the current tab, for banners
+    #[inline]
+    pub fn current_labeled_panes(&self) -> Vec<([f32; 2], String)> {
+        self.contexts
+            .get(self.current_index)
+            .map(|grid| grid.labeled_panes())
+            .unwrap_or_default()
     }
 
     #[inline]
@@ -703,7 +740,12 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             self.titles.last_title_update = Some(Instant::now());
             let mut id = String::default();
             for (i, context) in self.contexts.iter_mut().enumerate() {
-                let content = update_title(&self.config.title.content, context.current());
+                // The focused pane's user-defined label takes priority over the
+                // title template and is not overwritten by process/cwd/OSC changes
+                let content = match context.current_label() {
+                    Some(label) => label,
+                    None => update_title(&self.config.title.content, context.current()),
+                };
 
                 self.event_proxy
                     .send_event(TerminalEvent::Title(content.to_owned()), self.window_id);

--- a/frontends/omni-terminal/src/renderer/mod.rs
+++ b/frontends/omni-terminal/src/renderer/mod.rs
@@ -54,6 +54,7 @@ pub struct Renderer {
     pub config_blinking_interval: u64,
     ignore_selection_fg_color: bool,
     pub search: Search,
+    pub rename: Search,
     #[allow(unused)]
     pub option_as_alt: String,
     #[allow(unused)]
@@ -123,6 +124,7 @@ impl Renderer {
             visual_bell_active: false,
             visual_bell_start: None,
             search: Search::default(),
+            rename: Search::default(),
             font_cache: FontCache::new(),
             font_context: font_context.clone(),
             char_cache: CharCache::new(),
@@ -140,6 +142,56 @@ impl Renderer {
     #[inline]
     pub fn set_active_search(&mut self, active_search: Option<String>) {
         self.search.active_search = active_search;
+    }
+
+    #[inline]
+    pub fn set_active_rename(&mut self, active_rename: Option<String>) {
+        self.rename.active_search = active_rename;
+    }
+
+    /// Draw a small label banner at the top-left of each labeled pane
+    #[inline]
+    fn draw_pane_banners(
+        &mut self,
+        sugarloaf: &mut Sugarloaf,
+        panes: &[([f32; 2], String)],
+        objects: &mut Vec<Object>,
+    ) {
+        for (position, label) in panes {
+            // Approximate banner width from the label length; the exact glyph
+            // metrics are not needed for a compact indicator
+            let char_count = label.chars().count().min(24) as f32;
+            let banner_width = char_count * 9.0 + 12.0;
+
+            objects.push(Object::Quad(Quad {
+                position: *position,
+                color: self.named_colors.tabs_active,
+                size: [banner_width, 20.0],
+                ..Quad::default()
+            }));
+
+            let banner = sugarloaf.create_temp_rich_text();
+            sugarloaf.set_rich_text_font_size(&banner, 12.0);
+            let content = sugarloaf.content();
+            content
+                .sel(banner)
+                .clear()
+                .new_line()
+                .add_text(
+                    label,
+                    FragmentStyle {
+                        color: self.named_colors.tabs_active_foreground,
+                        ..FragmentStyle::default()
+                    },
+                )
+                .build();
+
+            objects.push(Object::RichText(RichText {
+                id: banner,
+                position: [position[0] + 4.0, position[1] + 2.0],
+                lines: None,
+            }));
+        }
     }
 
     #[inline]
@@ -816,15 +868,48 @@ impl Renderer {
 
     #[inline]
     fn update_search_rich_text(&mut self, content: &mut Content) {
-        if let Some(active_search_content) = &self.search.active_search {
-            if let Some(search_rich_text) = self.search.rich_text_id {
+        let active = self.search.active_search.clone();
+        let id = self.search.rich_text_id;
+        self.update_prompt_rich_text(
+            content,
+            active,
+            id,
+            "Search: ",
+            "Search: type something...",
+        );
+    }
+
+    #[inline]
+    fn update_rename_rich_text(&mut self, content: &mut Content) {
+        let active = self.rename.active_search.clone();
+        let id = self.rename.rich_text_id;
+        self.update_prompt_rich_text(
+            content,
+            active,
+            id,
+            "Rename: ",
+            "Rename: type a name...",
+        );
+    }
+
+    #[inline]
+    fn update_prompt_rich_text(
+        &mut self,
+        content: &mut Content,
+        active_content: Option<String>,
+        rich_text_id: Option<usize>,
+        prompt: &str,
+        empty_hint: &str,
+    ) {
+        if let Some(active_search_content) = &active_content {
+            if let Some(search_rich_text) = rich_text_id {
                 if active_search_content.is_empty() {
                     content
                         .sel(search_rich_text)
                         .clear()
                         .new_line()
                         .add_text(
-                            &String::from("Search: type something..."),
+                            &String::from(empty_hint),
                             FragmentStyle {
                                 color: [
                                     self.named_colors.foreground[0],
@@ -842,7 +927,7 @@ impl Renderer {
                         ..FragmentStyle::default()
                     };
                     let line = content.sel(search_rich_text);
-                    line.clear().new_line().add_text("Search: ", style);
+                    line.clear().new_line().add_text(prompt, style);
 
                     // Collect characters that need font lookups
                     let mut font_lookups = Vec::new();
@@ -911,6 +996,14 @@ impl Renderer {
             let search_rich_text = sugarloaf.create_temp_rich_text();
             sugarloaf.set_rich_text_font_size(&search_rich_text, 12.0);
             self.search.rich_text_id = Some(search_rich_text);
+        }
+
+        // In case rich text for the rename prompt was not created
+        let has_rename = self.rename.active_search.is_some();
+        if has_rename && self.rename.rich_text_id.is_none() {
+            let rename_rich_text = sugarloaf.create_temp_rich_text();
+            sugarloaf.set_rich_text_font_size(&rename_rich_text, 12.0);
+            self.rename.rich_text_id = Some(rename_rich_text);
         }
 
         // Apply background color change BEFORE cell rendering so cells
@@ -1190,6 +1283,7 @@ impl Renderer {
         }
 
         self.update_search_rich_text(sugarloaf.content());
+        self.update_rename_rich_text(sugarloaf.content());
 
         let window_size = sugarloaf.window_size();
         let scale_factor = sugarloaf.scale_factor();
@@ -1199,7 +1293,7 @@ impl Renderer {
             (window_size.width, window_size.height, scale_factor),
             &self.named_colors,
             context_manager,
-            self.search.active_search.is_some(),
+            has_search || has_rename,
             &mut objects,
         );
 
@@ -1217,9 +1311,33 @@ impl Renderer {
             self.search.rich_text_id = None;
         }
 
+        if has_rename {
+            if let Some(rich_text_id) = self.rename.rich_text_id {
+                search::draw_search_bar(
+                    &mut objects,
+                    rich_text_id,
+                    &self.named_colors,
+                    (window_size.width, window_size.height, scale_factor),
+                );
+            }
+
+            self.rename.active_search = None;
+            self.rename.rich_text_id = None;
+        }
+
         // let _duration = start.elapsed();
         context_manager.extend_with_grid_objects(&mut objects);
         // let _duration = start.elapsed();
+
+        // Per-pane label banners: only when the tab is split, otherwise a
+        // single pane's label already shows in the tab title/bar
+        if context_manager.current_is_split() {
+            self.draw_pane_banners(
+                sugarloaf,
+                &context_manager.current_labeled_panes(),
+                &mut objects,
+            );
+        }
 
         // Update visual bell state and set overlay if needed
         let visual_bell_active = self.update_visual_bell();

--- a/frontends/omni-terminal/src/renderer/navigation.rs
+++ b/frontends/omni-terminal/src/renderer/navigation.rs
@@ -47,6 +47,13 @@ impl ScreenNavigation {
 
         let titles = &context_manager.titles.titles;
 
+        // A single tab carrying a user-defined label reveals its bar even when
+        // `hide-if-single` is on, so the name is visible in-window. Only the
+        // text-rendering tab modes benefit (Bookmark draws dots, not text)
+        let reveal_single_label =
+            len == 1 && context_manager.current_pane_label().is_some();
+        let hide_if_single_tab = self.navigation.hide_if_single && !reveal_single_label;
+
         match self.navigation.mode {
             #[cfg(target_os = "macos")]
             NavigationMode::NativeTab => {}
@@ -69,7 +76,7 @@ impl ScreenNavigation {
                     len,
                     current,
                     position_y,
-                    self.navigation.hide_if_single,
+                    hide_if_single_tab,
                     dimensions,
                 );
             }
@@ -84,7 +91,7 @@ impl ScreenNavigation {
                     len,
                     current,
                     position_y,
-                    self.navigation.hide_if_single,
+                    hide_if_single_tab,
                     dimensions,
                 );
             }
@@ -215,8 +222,10 @@ impl ScreenNavigation {
             }
 
             let name_modifier = 90.;
-            if name.len() >= 14 {
-                name = name[0..14].to_string();
+            // Truncate by character, not byte, to avoid slicing a multibyte
+            // UTF-8 boundary (labels and titles may contain unicode)
+            if name.chars().count() > 14 {
+                name = name.chars().take(14).collect();
             }
 
             objects.push(Object::Quad(Quad {

--- a/frontends/omni-terminal/src/screen/mod.rs
+++ b/frontends/omni-terminal/src/screen/mod.rs
@@ -83,6 +83,8 @@ pub struct Screen<'screen> {
     pub mouse: Mouse,
     pub touchpurpose: TouchPurpose,
     pub search_state: SearchState,
+    /// When `Some`, the tab-rename prompt is active and holds its input buffer
+    pub rename_state: Option<String>,
     pub hint_state: HintState,
     pub renderer: Renderer,
     pub sugarloaf: Sugarloaf<'screen>,
@@ -258,6 +260,7 @@ impl Screen<'_> {
 
         Ok(Screen {
             search_state: SearchState::default(),
+            rename_state: None,
             hint_state: HintState::new(config.hints.alphabet.clone()),
             hints_config: config
                 .hints
@@ -699,6 +702,7 @@ impl Screen<'_> {
             if !mode.contains(Mode::REPORT_EVENT_TYPES)
                 || mode.contains(Mode::VI)
                 || self.search_active()
+                || self.rename_active()
                 || self.hint_state.is_active()
             {
                 return;
@@ -772,6 +776,12 @@ impl Screen<'_> {
             }
             self.update_hint_state();
             self.render();
+            return;
+        }
+
+        // While the rename prompt is open it captures all key input
+        if self.rename_active() {
+            self.rename_key(key);
             return;
         }
 
@@ -1127,6 +1137,9 @@ impl Screen<'_> {
                     }
                     Act::TabCreateNew => {
                         self.create_tab();
+                    }
+                    Act::RenameTab => {
+                        self.start_rename();
                     }
                     Act::TabCloseCurrent => {
                         self.close_tab();
@@ -2273,6 +2286,80 @@ impl Screen<'_> {
     }
 
     #[inline]
+    pub fn rename_active(&self) -> bool {
+        self.rename_state.is_some()
+    }
+
+    /// Open the rename prompt for the focused pane, prefilled with its label
+    fn start_rename(&mut self) {
+        let existing = self
+            .context_manager
+            .current_pane_label()
+            .unwrap_or_default();
+        self.rename_state = Some(existing);
+        self.render();
+    }
+
+    /// Commit the rename prompt: an empty value clears the label and reverts
+    /// the tab to its auto-derived title
+    fn confirm_rename(&mut self) {
+        if let Some(buffer) = self.rename_state.take() {
+            let trimmed = buffer.trim();
+            let label = if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            };
+            self.context_manager.set_current_pane_label(label);
+            // Refresh the tab bar immediately rather than on the next title tick
+            self.context_manager.update_titles();
+            // The reserved title strip shifts pane content, so force a full
+            // redraw to repaint panes at their new positions
+            self.context_manager
+                .current_mut()
+                .renderable_content
+                .pending_update
+                .set_ui_damage(terminal_backend::event::TerminalDamage::Full);
+        }
+        self.render();
+    }
+
+    fn cancel_rename(&mut self) {
+        self.rename_state = None;
+        self.render();
+    }
+
+    /// Route a key press to the active rename prompt
+    fn rename_key(&mut self, key: &terminal_window::event::KeyEvent) {
+        match key.logical_key.as_ref() {
+            Key::Named(NamedKey::Enter) => self.confirm_rename(),
+            Key::Named(NamedKey::Escape) => self.cancel_rename(),
+            Key::Named(NamedKey::Backspace) => {
+                if let Some(buffer) = self.rename_state.as_mut() {
+                    buffer.pop();
+                }
+                self.render();
+            }
+            _ => {
+                let text = key.text_with_all_modifiers().unwrap_or_default();
+                let mut changed = false;
+                for c in text.chars() {
+                    // Printable ASCII and unicode only, ignore control characters
+                    if (' '..='~').contains(&c) || c >= '\u{a0}' {
+                        if let Some(buffer) = self.rename_state.as_mut() {
+                            buffer.push(c);
+                            changed = true;
+                        }
+                    }
+                }
+                if changed {
+                    self.render();
+                }
+            }
+        }
+    }
+
+    #[inline]
     fn search_input(&mut self, c: char) {
         match self.search_state.history_index {
             Some(0) => (),
@@ -2745,6 +2832,17 @@ impl Screen<'_> {
                     .pending_update
                     .set_ui_damage(terminal_backend::event::TerminalDamage::Full);
             }
+        }
+
+        if let Some(buffer) = &self.rename_state {
+            self.renderer.set_active_rename(Some(buffer.clone()));
+
+            // Force a full UI redraw so the prompt bar repaints on each keystroke
+            let current = self.context_manager.current_mut();
+            current
+                .renderable_content
+                .pending_update
+                .set_ui_damage(terminal_backend::event::TerminalDamage::Full);
         }
 
         // let renderer_run_start = std::time::Instant::now();


### PR DESCRIPTION
## Summary

Adds custom, human-readable labels for panes/tabs. Press `Ctrl+Shift+L` (`Cmd+Shift+L` on macOS), or bind the new `renameTab` action, to name the focused pane.

- Label overrides the auto-derived title and survives process, cwd, and OSC title changes; committing an empty value reverts
- Focused pane's label drives the tab title
- A single labeled tab reveals its bar in `TopTab`/`BottomTab` modes even with `hide-if-single` on
- In a split, each labeled pane reserves a one-line title strip so every pane name is visible without overlapping content
- Fixes a latent panic in tab-name truncation on multibyte (unicode) names

## Test plan

- `cargo test -p omni-terminal` (133 pass), clippy + fmt clean
- Verified interactively: rename single tab, split (right + stacked), per-pane labels, clear-to-revert, unicode names

Docs updated in the omni/docs repo (keybindings + configuration).