### PR TITLE
fix(wasm): attach mouseup/mousemove to window so selection releases off-canvas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "copa"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "arrayvec",
  "criterion",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "corcovado"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "cfg-if 1.0.4",
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "omni-terminal"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "axum",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "omni-terminal-android"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "android_logger",
  "copa",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "omni-terminal-wasm"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
@@ -4522,7 +4522,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sugarloaf"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "approx",
  "bytemuck",
@@ -4609,7 +4609,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "teletypewriter"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "corcovado",
  "dirs",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "terminal-backend"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "base64",
  "bitflags 2.11.0",
@@ -4676,7 +4676,7 @@ dependencies = [
 
 [[package]]
 name = "terminal-emulator"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "copa",
  "sugarloaf",
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "terminal-proc-macros"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4692,7 +4692,7 @@ dependencies = [
 
 [[package]]
 name = "terminal-window"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "atomic-waker",

--- a/frontends/wasm/src/lib.rs
+++ b/frontends/wasm/src/lib.rs
@@ -1212,10 +1212,20 @@ async fn async_main(container_id: String, ws_url: String, font_size: f32) {
             let selecting = selecting.clone();
             let cw = cell_width;
             let ch = cell_height;
+            let canvas_for_up = canvas.clone();
             let on_mouseup = Closure::<dyn FnMut(web_sys::MouseEvent)>::new(
                 move |event: web_sys::MouseEvent| {
-                    let (col, row) =
-                        pixel_to_cell(event.offset_x(), event.offset_y(), cw, ch);
+                    // Compute canvas-relative coords: this listener is on `window`
+                    // (so a release anywhere ends the selection), where
+                    // `offset_x/y` would be relative to whatever element is under
+                    // the pointer, not the canvas.
+                    let rect = canvas_for_up.get_bounding_client_rect();
+                    let (col, row) = pixel_to_cell(
+                        f64::from(event.client_x()) - rect.left(),
+                        f64::from(event.client_y()) - rect.top(),
+                        cw,
+                        ch,
+                    );
 
                     let button = x11_button(event.button());
                     let mods = mouse_modifiers(&event);
@@ -1253,7 +1263,8 @@ async fn async_main(container_id: String, ws_url: String, font_size: f32) {
                     }
                 },
             );
-            canvas_element
+            web_sys::window()
+                .unwrap()
                 .add_event_listener_with_callback(
                     "mouseup",
                     on_mouseup.as_ref().unchecked_ref(),
@@ -1270,10 +1281,19 @@ async fn async_main(container_id: String, ws_url: String, font_size: f32) {
             let selecting = selecting.clone();
             let cw = cell_width;
             let ch = cell_height;
+            let canvas_for_move = canvas.clone();
             let on_mousemove = Closure::<dyn FnMut(web_sys::MouseEvent)>::new(
                 move |event: web_sys::MouseEvent| {
-                    let (col, row) =
-                        pixel_to_cell(event.offset_x(), event.offset_y(), cw, ch);
+                    // Canvas-relative coords: this listener is on `window` so a
+                    // drag that leaves the canvas still extends the selection;
+                    // `offset_x/y` would be relative to the wrong element there.
+                    let rect = canvas_for_move.get_bounding_client_rect();
+                    let (col, row) = pixel_to_cell(
+                        f64::from(event.client_x()) - rect.left(),
+                        f64::from(event.client_y()) - rect.top(),
+                        cw,
+                        ch,
+                    );
 
                     // Update text selection during drag
                     if *selecting.borrow() {
@@ -1328,7 +1348,8 @@ async fn async_main(container_id: String, ws_url: String, font_size: f32) {
                     }
                 },
             );
-            canvas_element
+            web_sys::window()
+                .unwrap()
                 .add_event_listener_with_callback(
                     "mousemove",
                     on_mousemove.as_ref().unchecked_ref(),


### PR DESCRIPTION
## Summary
Dragging a text selection in the terminal and releasing the mouse **outside** the canvas left `selecting` stuck true (the `mouseup` listener was canvas-bound and never fired off-canvas), so the cursor never let go.

## Fix (`frontends/wasm/src/lib.rs`)
- Attach `mouseup` and `mousemove` to `window` instead of the canvas (`mousedown` stays on the canvas so selection still only starts there).
- Compute the grid cell from canvas-relative `clientX/Y` minus the canvas rect, so off-canvas positions map correctly. Closures stay `.forget()`-detached.
- Syncs `Cargo.lock` to the committed 0.3.0 workspace versions (was stale at 0.2.4).

The rebuilt WASM artifacts were shipped to fractal-app (public/terminal) in fractal-app#87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)