### PR TITLE
fix(terminal): stop long tab labels overflowing and number every tab

### DIFF
--- a/.changeset/tab-label-overflow.md
+++ b/.changeset/tab-label-overflow.md
@@ -1,0 +1,5 @@
+---
+"@omnidotdev/terminal": patch
+---
+
+Fix long tab names overflowing into the next tab. Labels are now truncated to the tab's measured pixel width (rather than a fixed character count) and ellipsized, and the numeric/active-marker prefix is counted against the same budget so it can no longer push the name past the tab edge.

--- a/.changeset/tab-label-overflow.md
+++ b/.changeset/tab-label-overflow.md
@@ -2,4 +2,6 @@
 "@omnidotdev/terminal": patch
 ---
 
-Fix long tab names overflowing into the next tab. Labels are now truncated to the tab's measured pixel width (rather than a fixed character count) and ellipsized, and the numeric/active-marker prefix is counted against the same budget so it can no longer push the name past the tab edge.
+Fix long tab names overflowing into the next tab. Labels are now truncated to the tab's measured pixel width (rather than a fixed character count) and ellipsized, and the numeric prefix is counted against the same budget so it can no longer push the name past the tab edge.
+
+Every tab now shows a numeric prefix, including the active one, so prefix widths are uniform across the tab bar. The active tab is distinguished by its color and highlight underline rather than a separate marker glyph.

--- a/frontends/omni-terminal/src/renderer/navigation.rs
+++ b/frontends/omni-terminal/src/renderer/navigation.rs
@@ -233,11 +233,10 @@ impl ScreenNavigation {
 
             let name_modifier = 90.;
 
-            let prefix = if is_current {
-                String::from("▲ ")
-            } else {
-                format!("{}.", i + 1)
-            };
+            // Every tab is numbered (active included) so the prefix width is
+            // uniform; the active tab is distinguished by its color and the
+            // highlight underline below, not by a separate marker glyph
+            let prefix = format!("{}.", i + 1);
 
             // Budget the whole label (prefix + name) to the tab's pixel width so
             // long names do not overflow into the next tab. The tab quad is

--- a/frontends/omni-terminal/src/renderer/navigation.rs
+++ b/frontends/omni-terminal/src/renderer/navigation.rs
@@ -193,6 +193,16 @@ impl ScreenNavigation {
             tabs = Vec::from_iter(current - screen_limit..len);
         }
 
+        // Measure the monospace cell advance at the tab font size (14px) once so
+        // labels can be truncated to the tab's actual pixel width. A fixed
+        // character count cannot work here: cell width varies by font, so it
+        // overflows wide fonts and wastes space on narrow ones
+        let cell_width = {
+            let measure = sugarloaf.create_temp_rich_text();
+            sugarloaf.set_rich_text_font_size(&measure, 14.);
+            sugarloaf.get_rich_text_dimensions(&measure).width
+        };
+
         for i in tabs {
             let mut background_color = colors.bar;
             let mut foreground_color = colors.tabs_foreground;
@@ -222,10 +232,30 @@ impl ScreenNavigation {
             }
 
             let name_modifier = 90.;
-            // Truncate by character, not byte, to avoid slicing a multibyte
-            // UTF-8 boundary (labels and titles may contain unicode)
-            if name.chars().count() > 14 {
-                name = name.chars().take(14).collect();
+
+            let prefix = if is_current {
+                String::from("▲ ")
+            } else {
+                format!("{}.", i + 1)
+            };
+
+            // Budget the whole label (prefix + name) to the tab's pixel width so
+            // long names do not overflow into the next tab. The tab quad is
+            // 125px wide with a 4px left inset, so reserve a matching 4px right
+            // inset. Truncate by character, not byte, to avoid slicing a
+            // multibyte UTF-8 boundary (labels and titles may contain unicode)
+            let max_chars = if cell_width > 0. {
+                ((125. - 8.) / cell_width).floor() as usize
+            } else {
+                14
+            };
+            let name_budget = max_chars.saturating_sub(prefix.chars().count());
+            if name.chars().count() > name_budget {
+                name = name
+                    .chars()
+                    .take(name_budget.saturating_sub(1))
+                    .collect::<String>()
+                    + "…";
             }
 
             objects.push(Object::Quad(Quad {
@@ -251,11 +281,7 @@ impl ScreenNavigation {
                 }));
             }
 
-            let text = if is_current {
-                format!("▲ {name}")
-            } else {
-                format!("{}.{name}", i + 1)
-            };
+            let text = format!("{prefix}{name}");
 
             let tab = sugarloaf.create_temp_rich_text();
             sugarloaf.set_rich_text_font_size(&tab, 14.);


### PR DESCRIPTION
## Summary

Long tab names overflowed into the neighboring tab. Two related changes to the `TopTab`/`BottomTab` label rendering in `frontends/omni-terminal/src/renderer/navigation.rs`:

- **Truncate labels to pixel width, not a fixed char count.** Labels were cut to 14 characters, but the prefix was prepended *after* truncation and a character count does not track a font's pixel width, so long names spilled past the 125px tab. The monospace cell advance is now measured once at the tab font size, and the whole label (prefix included) is budgeted to the tab width and ellipsized when it overflows.
- **Number every tab, drop the active-tab marker glyph.** The active tab was prefixed with `▲ ` instead of a number, giving it a different prefix width from its neighbors. All tabs are now numbered; the active tab is still distinguished by its color and the existing highlight underline.

## Testing

Built and ran the app; verified long labels truncate with an ellipsis and stay inside their tab, and that the active tab is numbered and clearly highlighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)